### PR TITLE
Limit babel and postcss support to browsers with a greater than 0.5% share

### DIFF
--- a/lib/.babelrc
+++ b/lib/.babelrc
@@ -3,7 +3,7 @@
     ["@babel/env", {
       "targets": {
         "browsers": [
-          "last 2 versions"
+          ">0.5%"
         ],
         "node": "current"
       }

--- a/lib/postcss.config.js
+++ b/lib/postcss.config.js
@@ -3,7 +3,7 @@
 module.exports = {
   plugins: [
     require('autoprefixer', {
-      browsers: ['last 2 versions']
+      browsers: ['>0.5%']
     })
   ]
 };


### PR DESCRIPTION
Using "last 2 versions" for babel and postcss via browserlist is too broad and leads to larger than necessary bundle sizes.

Here's the list of browsers we will now support: http://browserl.ist/?q=%3E0.5%25